### PR TITLE
Add usage documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@ View the README.md guide for the front end website for further details
 ## Usage
 To run, start the containers with `docker-compose up`.
 
+### Ports
+
+| Service | Port |
+| :-------| :---:|
+| API     | 5000 |
+| Database| 5432 |
+| Redis   | 6379 |
+

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@ Backend repository for Voter's Voice website.
 
 View the README.md guide for the front end website for further details  
 [https://github.com/opensandiego/sdvv-frontend/blob/master/README.md](https://github.com/opensandiego/sdvv-frontend/blob/master/README.md)
+
+## Usage
+To run, start the containers with `docker-compose up`.
+


### PR DESCRIPTION
This adds documentation to README.md about how to use this project and the ports the services are on.

Closes issue #15.