### PR TITLE
Added support for fetching agency, election, and candidate names from NetFile

### DIFF
--- a/app/scripts/node/netfile/netfileAgencies.js
+++ b/app/scripts/node/netfile/netfileAgencies.js
@@ -1,0 +1,29 @@
+const network = require('./network');
+
+function getCampaignAgenciesRequestBody(includeTestAgencies) {
+
+  return {
+    "IncludeTestAgencies": includeTestAgencies
+  };
+
+}
+
+/**
+ * @param {boolean} includeTestAgencies
+ */
+async function getAgencies(includeTestAgencies = false) {
+  const campaignAgenciesUrl = 'https://www.netfile.com:443/Connect2/api/public/campaign/agencies';
+
+  const requestBody = getCampaignAgenciesRequestBody(includeTestAgencies);
+  const options = network.getPostRequestOptions(requestBody);
+
+  const response = JSON.parse( await network.doRequest(campaignAgenciesUrl, options) );
+
+  const agencies = response.agencies;
+
+  return agencies;
+}
+
+module.exports = {
+  getAgencies,
+}

--- a/app/scripts/node/netfile/network.js
+++ b/app/scripts/node/netfile/network.js
@@ -1,0 +1,75 @@
+const fetch = require('node-fetch');
+const pRetry = require('p-retry');
+
+/**
+ * Performs Fetch from a URL.
+ * @param {string} url 
+ * @param {object} options - Options for the fetch request passed
+ * @returns {string}
+ */
+async function doFetch(url, options) {
+
+  if (!options) {
+    options = {
+      headers: { 'Content-Type': 'application/json' },
+    }
+  }
+
+  const fetchResponse = await fetch(url, options);
+
+  // Abort retrying if the resource doesn't exist
+  if (fetchResponse.status === 404) {
+    throw new pRetry.AbortError(fetchResponse.statusText);
+
+  // cause a retry if the response is not 200
+  } else if (fetchResponse.status !== 200) {
+    throw new Error(fetchResponse.statusText);
+  }
+
+  return fetchResponse.text();
+}
+
+
+/**
+ * Fetches data from a url with retries with exponential back off.
+ * @param {string} url
+ * @param {object} requestOptions - passed through to doFetch
+ * @param {object} [options]
+ * @param {number} [options.retries = 10]
+ * @returns {string}
+ */
+async function doRequest(url, requestOptions, {retries = 10} = {}) {
+
+  // Call this function just before each failed attempt then retry doFetch
+  const doOnEachFailedAttempt = (error) => {
+    console.log(`Fetch attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`);
+  }
+
+  try {
+    // Main function for doRequest
+    return await pRetry(
+      () => doFetch(url, requestOptions),
+      { retries, minTimeout: 1000, onFailedAttempt: doOnEachFailedAttempt }
+    );
+
+  } catch (error) {
+    console.log(error.toString());
+    console.log('Error: doRequest > Fetch Retry.');
+    console.log('Error: This maybe a network error or the maximum number of retries have been reached.');
+    throw error;
+  }
+
+}
+
+function getPostRequestOptions(requestBody) {
+  return {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+    headers: { 'Content-Type': 'application/json' },
+  };
+}
+
+module.exports = {
+  doRequest,
+  getPostRequestOptions,
+};

--- a/app/scripts/node/netfile/publicPortalWebScraper.js
+++ b/app/scripts/node/netfile/publicPortalWebScraper.js
@@ -1,0 +1,185 @@
+'use strict';
+const puppeteer = require('puppeteer');
+
+const getLiHandles = async (handle, selector = ':scope ') =>
+  await Promise.all( await handle.$$(`${selector} > li`) );
+
+const getBranchText = async (handle) =>
+  await (await (await handle.$(`:scope > div > .rtIn`))
+    .getProperty('innerText')).jsonValue();
+
+async function getNetFilePage(aid, browser) {
+  const page = await browser.newPage();
+
+  await page.goto(`https://public.netfile.com/pub2/?aid=${aid}`, {
+    waitUntil: "networkidle2"
+  });
+
+  return page;
+}
+
+async function expandNode(page, handle) {
+
+  let returnList = [];
+  
+  const listLIHandles = await getLiHandles(handle);
+
+  for (const liHandle of listLIHandles) {
+    
+    const branchText = await getBranchText(liHandle);
+
+    const plusHandle = await liHandle.$(`:scope > div > span.rtPlus`);
+
+    if (!plusHandle) {
+      returnList.push({ name: branchText });
+      continue;
+    }
+
+    await plusHandle.evaluate(element => element.click());
+
+    // Skip if the child Ul element has not been added.
+    try {
+      await page.waitForFunction(
+        element => element.querySelector(':scope > ul.rtUL') !== null, 
+        { polling: 1000, timeout: 10000 },
+        liHandle
+      );
+    } catch (e) {
+      // console.error(e.message);
+      // console.error(`Skipping: ${branchText}`);
+      continue;
+    }
+
+    const UlHandle =  await liHandle.$(`:scope > ul.rtUL`)
+    
+    returnList.push({
+      name: branchText,
+      elements: await expandNode(page, UlHandle)
+    })
+
+  }
+
+  return returnList;
+}
+
+
+async function getElectionCycleLiHandle(parentHandle, electionCycleTitle) {
+  // listLIHandles will be all of the child li node elements of parentHandle
+  let listLIHandles = await getLiHandles(parentHandle);
+ 
+  // Find the liHandle within listLIHandles that has text that matches electionCycleTitle
+  for (const liHandle of  listLIHandles) {
+    let branchText = await getBranchText(liHandle);
+
+    if (branchText === electionCycleTitle) {
+      return liHandle;
+    }
+  }
+
+  throw new Error(`Cycle title '${electionCycleTitle}' not found.`);
+}
+
+async function getElectionCycleUlHandle(page, branchHandle, electionCycleTitle) {
+ 
+  let cycleLIHandle = await getElectionCycleLiHandle(branchHandle, electionCycleTitle);
+
+  let plusHandle = await cycleLIHandle.$(`:scope > div > span.rtPlus`);
+
+  if (!plusHandle) throw new Error(`Not able to expand Cycle '${electionCycleTitle}.'`);
+  
+  // Clicking on the plusHandle element causes the page to make a network request and add a child ul element.
+  await plusHandle.evaluate(element => element.click());
+
+  // Do not continue if the child Ul element has not been added.
+  try {
+    await page.waitForFunction(
+      element => element.querySelector(':scope > ul.rtUL') !== null,
+      { polling: 1000, timeout: 10000 },
+      cycleLIHandle
+    );    
+  } catch (e) {
+    throw new Error(`Not able to use: ${electionCycleTitle}`);
+  }
+
+  return await cycleLIHandle.$(`:scope > ul.rtUL`);
+}
+
+
+/**
+ * @param {string} aid - Example: "CSD"
+ * @returns {string[]} - Examples: ["11/03/2020 General Election", "03/03/2020 Primary Election"]
+ */
+async function electionCycleTitles(aid) {
+  let titles = [];
+  const browser = await puppeteer.launch({headless: true});
+
+  try {
+    const electionCycleRootULSelector = '#ctl00_phBody_browseElections_treeBrowse > ul';
+    
+    const page = await getNetFilePage(aid, browser);
+    let rootHandle = await page.waitForSelector(electionCycleRootULSelector);
+    let listLIHandles = await getLiHandles(rootHandle);
+
+    for (const liHandle of  listLIHandles) {
+      titles.push(await getBranchText(liHandle));
+    }
+
+  } catch {
+    console.error(error);
+  } finally {
+    await browser.close();
+    return titles;
+  }
+
+}
+
+/**
+ * @param {string} aid - Example: "CSD"
+ * @param {string[]} titles - Examples: ["11/03/2020 General Election", "03/03/2020 Primary Election"]
+ */
+async function getMultipleElectionCycleCandidates(aid, titles) {
+  titles = Array.isArray(titles) ? titles : [ titles ];
+
+  let forest = [];
+
+  for await (const title of titles) {
+    const tree = await getElectionCycleCandidates(aid, title);
+    forest.push(tree);
+  }
+
+  return forest;
+}
+
+
+/**
+ * @param {string} aid - Example: "CSD"
+ * @param {string} electionCycleTitle - Example: "11/03/2020 General Election"
+ */
+async function getElectionCycleCandidates(aid, electionCycleTitle = '') {
+  let tree = {};
+  const browser = await puppeteer.launch({headless: true});
+
+  try {
+    const page = await getNetFilePage(aid, browser)
+    
+    const electionCycleRootULSelector = '#ctl00_phBody_browseElections_treeBrowse > ul';
+    let rootHandle = await page.waitForSelector(electionCycleRootULSelector);
+    
+    if (electionCycleTitle !== '') {
+      rootHandle = await getElectionCycleUlHandle(page, rootHandle, electionCycleTitle);
+    }
+    
+    tree.cycle = electionCycleTitle
+    tree.electionItems = await expandNode(page, rootHandle);
+  } catch (error) {
+    console.error(error.message);
+  } finally {
+    await browser.close();
+    return tree;
+  }
+}
+
+module.exports = {
+  electionCycleTitles,
+  getMultipleElectionCycleCandidates,
+};


### PR DESCRIPTION
- **network.js is** - used by other functions to make http requests using node-fetch and p-retry.
- **netfileAgencies.js** - used to fetch agency data from the NetFile API.
- **publicPortalWebScraper.js** - is used to scrape the NetFile Public Portal for Campaign Finance Disclosure site to obtain the list of elections for a given agency, it is also used to obtain the offices and candidate names for a given agency and election.

The NetFile URL used for the agency data is: `https://www.netfile.com:443/Connect2/api/public/campaign/agencies`

An example NetFile Public Portal url where the 'CSD' can be replaced with an agencies short name:  `https://public.netfile.com/pub2/?aid=CSD`