### PR TITLE
Command line interface to populate the database

### DIFF
--- a/app/scripts/node/cli/agenciesMenu.js
+++ b/app/scripts/node/cli/agenciesMenu.js
@@ -1,0 +1,59 @@
+'use strict';
+const inquirer = require('inquirer');
+
+
+async function mainMenu() {
+  
+  const prompt = [{
+    type: "list",
+    name: "agenciesMenu",
+    message: "Agencies",
+    choices: [
+      {
+        name: "Update from NetFile",
+        value: "updateTable",
+      },
+      {
+        name: "Return to previous menu",
+        value: "previousMenu",
+      },
+    ],
+  }];
+
+  const answers = await inquirer.prompt(prompt);
+
+  if (answers.agenciesMenu === "updateTable") {
+    await updateAgencies();
+  } else if (answers.agenciesMenu === "previousMenu") {
+    return false;
+  }
+
+  return true;
+}
+
+async function updateAgencies(){
+
+  const answers = await inquirer.prompt([{
+    type: "confirm",
+    name: "doUpdate",
+    message: "Confirm update of agencies in database from NetFile API",
+  }]);
+
+  if (answers.doUpdate) {
+    
+    try {
+      const update = require("./update");
+      await update.updateAgencies();
+    } catch(e) {
+      console.log('Error updating agencies from NetFile API.');
+      console.log(e);
+      return;
+    }
+
+  }
+}
+
+
+module.exports = {
+  menu: mainMenu,
+}

--- a/app/scripts/node/cli/candidatesMenu.js
+++ b/app/scripts/node/cli/candidatesMenu.js
@@ -1,0 +1,129 @@
+'use strict';
+const inquirer = require('inquirer');
+
+const update = require('./update');
+const query = require('./query');
+const menuUtil = require('./menuUtil');
+
+
+async function mainMenu() {
+  const agenciesInDB = await query.getAgencies();
+  const agenciesWithElections = await query.getAgencyElections();
+  const combinedAgencies = menuUtil.combineAgencies(agenciesWithElections, agenciesInDB);
+  const sortedAgencies= menuUtil.sortAgencies(combinedAgencies);
+  const agencyElections = menuUtil.getAgenciesMenu(sortedAgencies);
+
+  const moreOptions = [{
+    name: `Return to previous menu`,
+    value: 'previousMenu',
+  }];
+
+  const choicesList = [].concat(
+    moreOptions,
+    new inquirer.Separator(),
+    agencyElections,
+    new inquirer.Separator(),
+  );
+
+  const prompt = [{
+    type: "list",
+    name: "electionsMenu",
+    message: "Agencies - To add candidates choose agency -> election ",
+    choices: choicesList,
+    pageSize: 10,
+  }];
+
+  const answers = await inquirer.prompt(prompt);
+
+  if (answers.electionsMenu === "previousMenu") {
+    return false;
+  } else {
+
+    const found = agencyElections.find( item => item.value === answers.electionsMenu);
+    if (found) {
+      await menuUtil.menuLoop(listElections, [found.value]);
+    }
+  }
+
+  return true;
+}
+
+async function listElections(shortName) {
+  const electionsInDB = await query.getElectionsFromDB(shortName);
+  const electionsFromNetFile = await query.getElections(shortName, false);
+  
+  const combinedElections = menuUtil.combineElections(electionsInDB, electionsFromNetFile);
+  const sortedElections = menuUtil.sortElections(combinedElections);
+  const electionChoices = menuUtil.getElectionsMenu(sortedElections);
+
+  const previousMenuOption = {
+    name: `Return to previous menu`,
+    value: 'previousMenu',
+  };
+
+  const getUpdatedElectionsOption = {
+    name: `Update list of elections for ${shortName} from NetFile.`,
+    value: 'updateElections',
+  };
+
+  const choicesList = [].concat(
+    previousMenuOption,
+    new inquirer.Separator(),
+    electionChoices,
+    new inquirer.Separator(),
+    getUpdatedElectionsOption,
+  );
+
+  const prompt = [{
+    type: "list",
+    name: "menu",
+    message: "Candidates by elections menu",
+    choices: choicesList,
+    pageSize: 10,
+    loop: false,
+  }];
+
+  const answers = await inquirer.prompt(prompt);
+
+  if (answers.menu === "previousMenu") {
+    return false;
+  } else if (answers.menu === "updateElections") {
+    if (await confirmationMenu("Update list of elections, may take 10 - 30 seconds?")) {
+      await query.getElections(shortName, true);
+    }
+  } else {
+
+    const found = electionChoices.find( election => election.value === answers.menu);
+    if (found) {
+      if (await confirmationMenu("Update candidates for election, may take 1 - 3 minutes?")) {
+        console.log(`Retrieving ${shortName} candidates for: ${found.value} ...`);
+        await update.updateElections(found.value, shortName);
+      }
+    }
+
+  }
+
+  return true;
+}
+
+async function confirmationMenu(message) {
+
+  const prompt = [{
+    type: "confirm",
+    name: "doUpdate",
+    message: message,
+    default: false,
+  }];
+
+  const answers = await inquirer.prompt(prompt); 
+  return answers.doUpdate;
+}
+
+
+async function menu() {
+  await menuUtil.menuLoop(mainMenu);
+}
+
+module.exports = {
+  menu,
+}

--- a/app/scripts/node/cli/index.js
+++ b/app/scripts/node/cli/index.js
@@ -1,9 +1,72 @@
 'use strict';
-const inquirer = require("inquirer");
+const inquirer = require('inquirer');
+const agenciesMenu = require('./agenciesMenu');
+const candidatesMenu = require('./candidatesMenu');
+const status = require('./status');
+const menuUtil = require('./menuUtil');
 
-async function mainMenu() {}
+
+async function mainMenu() {
+
+  const agenciesStatus = await status.agenciesStatus();
+  const agenciesMenuText = menuUtil.getAgenciesMenuText(agenciesStatus);
+
+  const prompt = [{
+    type: "list",
+    name: "mainMenu",
+    message: "Voters Voice Database Dashboard Administration",
+    choices: [
+      {
+        name: agenciesMenuText,
+        value: "agencies",
+      },
+      {
+        name: "Elections/Candidates",
+        value: "candidates",
+        disabled: agenciesStatus.count < 1 ? 'agencies need to be updated' : false,
+      },
+      {
+        name: "Filings",
+        value: "filings",
+        disabled: true,
+      },
+      {
+        name: "Transactions",
+        value: "transactions",
+        disabled: true,
+      },
+      {
+        name: "Sync Database models",
+        value: "syncModels",
+      },
+      {
+        name: "Exit",
+        value: "exit",
+      },
+    ],
+  }];
+
+  const answers = await inquirer.prompt(prompt);
+
+  if (answers.mainMenu === "agencies") {
+    await agenciesMenu.menu();
+  } else if (answers.mainMenu === "candidates") {
+    await candidatesMenu.menu();
+  } else if (answers.mainMenu === "syncModels") {
+
+    console.log('Syncing all models...')
+    const db = require('../../../models/index')
+    const sequelize = db.sequelize
+    sequelize.sync({ alter: true })
+
+  } else if (answers.mainMenu === "exit") {
+    return false;
+  }
+
+  return true;
+}
 
 
 ;(async () => {
-  await mainMenu();
+  await menuUtil.menuLoop(mainMenu);
 })();

--- a/app/scripts/node/cli/index.js
+++ b/app/scripts/node/cli/index.js
@@ -1,0 +1,9 @@
+'use strict';
+const inquirer = require("inquirer");
+
+async function mainMenu() {}
+
+
+;(async () => {
+  await mainMenu();
+})();

--- a/app/scripts/node/cli/menuUtil.js
+++ b/app/scripts/node/cli/menuUtil.js
@@ -1,0 +1,130 @@
+'use strict';
+
+async function menuLoop(menuFn, args = []) {
+  let continueLoop = false;
+
+  do {
+    continueLoop = await menuFn(...args);
+  } while (continueLoop)
+
+  return true;
+}
+
+
+function getAgenciesMenuText(status) {
+  return `Agencies (count: ${status.count}, `
+    + `last update: ${status.lastUpdate})`;
+}
+
+function getFilingsMenuText(status) {
+  return `Filings (count: ${status.count})`;
+}
+
+function getTransactionsMenuText(status) {
+  return `Transactions (count: ${status.count})`;
+}
+
+
+function combineAgencies(agenciesWithElections, agenciesInDB) {
+
+  const agencies = agenciesInDB.map(agency => {
+
+    const found = agenciesWithElections
+      .find(element => element.agencyShortName === agency.shortcut);  
+
+    return {
+      shortName: agency.shortcut,
+      name: agency.name,
+      inDB: found ? true : false,
+      electionTitleCount: found ? found.electionTitleCount : null,
+      mostRecentElectionDate: found ? found.mostRecentElectionDate : null,
+    };
+
+  });
+
+  return agencies;
+}
+
+function sortAgencies(agencies) {
+
+  let sorted = agencies.sort((a, b) => a.name.localeCompare(b.name));
+  sorted = sorted.sort((a, b) => (a.inDB === b.inDB)? 0 : a.inDB ? -1 : 1);
+
+  return sorted
+}
+
+function getAgenciesMenu(agencies) {
+
+  return agencies.map( agency => {
+    const nameSuffix = agency.inDB ? `, (${agency.electionTitleCount} elections, ` +
+        `most recent: ${agency.mostRecentElectionDate.toLocaleDateString()})` : '';
+
+    return { 
+      name: `${agency.shortName}, '${agency.name}'${nameSuffix}`,
+      value: `${agency.shortName}`,
+    }
+  });
+
+}
+
+
+function combineElections(electionsFromDB, electionsFromNetFile) {
+  
+  const fullElectionTitles = electionsFromDB.map(election => election.fullElectionTitle);
+
+  const combinedTitles = Array.from(new Set([].concat(fullElectionTitles, electionsFromNetFile)));
+
+  const combinedElections = combinedTitles.map(electionTitle => {
+    const found = electionsFromDB.find( electionFromDB => electionFromDB.fullElectionTitle === electionTitle);
+
+    const election = found ? found : { fullElectionTitle: electionTitle };
+    election.inDB = found ? true : false;
+
+    return election;
+  });
+
+  return combinedElections;
+}
+
+function sortElections(elections) {
+
+  return elections.sort((firstElection, secondElection) => {
+    const firstDate = new Date((firstElection.fullElectionTitle.split(' '))[0]);
+    const secondDate = new Date((secondElection.fullElectionTitle.split(' '))[0]);
+
+    return (firstDate < secondDate) ? 1 : -1;
+  });
+
+}
+
+function getElectionsMenu(elections) {
+  return elections.map( election => {
+
+    const name = election.inDB 
+      ? `(${election.candidatesCount} candidates, ${election.count} offices, `
+        + `last updated from NetFile on ${election.lastUpdated.toLocaleDateString()})`
+      : '';
+    
+    return {
+      name: `${election.fullElectionTitle} ${name}`,
+      value: `${election.fullElectionTitle}`,
+    }
+  });
+}
+
+
+module.exports = {
+  menuLoop,
+
+  getAgenciesMenuText,
+  getFilingsMenuText,
+  getTransactionsMenuText,
+
+  combineAgencies,
+  sortAgencies,
+  getAgenciesMenu,
+
+  combineElections,
+  sortElections,
+  getElectionsMenu,
+}

--- a/app/scripts/node/cli/menuUtil.js
+++ b/app/scripts/node/cli/menuUtil.js
@@ -101,7 +101,7 @@ function getElectionsMenu(elections) {
   return elections.map( election => {
 
     const name = election.inDB 
-      ? `(${election.candidatesCount} candidates, ${election.count} offices, `
+      ? `(${election.candidatesCount} candidates, ${election.officesCount} offices, `
         + `last updated from NetFile on ${election.lastUpdated.toLocaleDateString()})`
       : '';
     

--- a/app/scripts/node/cli/query.js
+++ b/app/scripts/node/cli/query.js
@@ -1,0 +1,99 @@
+'use strict';
+const db = require('../../../models/index');
+const AgencyModel = db.sequelize.models.Agency;
+const CandidateModel = db.sequelize.models.Candidate;
+const Sequelize = require('sequelize');
+const netFilePortalScraper = require('../netfile/publicPortalWebScraper');
+
+
+async function doesTableExist(model) {
+  let exists = true;
+
+  try {
+    await model.findAll();
+  } catch(error) {
+    if (error instanceof Sequelize.DatabaseError) {
+      exists = false;
+    } else {
+      throw error;
+    }
+  }
+
+  return exists;
+}
+
+async function getAgencies() {
+  const tableExits = await doesTableExist(AgencyModel);
+    
+  if (!tableExits) { return []; }
+
+  return await AgencyModel.findAll({ raw: true, });
+}
+
+/**
+ * @param {string} agencyShortName - Example: "CSD"
+ * @param {boolean} [forceUpdate = true]
+ */
+async function getElections(agencyShortName, forceUpdate = true){
+  getElections.shortNameElectionsCache = getElections.shortNameElectionsCache || new Map();
+
+  const elections = getElections.shortNameElectionsCache.get(agencyShortName);
+  if (elections) {
+    return elections;
+  } else if (!forceUpdate) {
+    return [];
+  }
+
+  const results = await netFilePortalScraper.electionCycleTitles(agencyShortName);
+
+  getElections.shortNameElectionsCache.set(agencyShortName, results);
+
+  return results;
+}
+
+async function getAgencyElections() {
+
+  const results = await CandidateModel.findAll({
+    attributes: [ 
+      'agencyShortName',
+      [Sequelize.literal('COUNT(DISTINCT("fullElectionTitle"))'), 'electionTitleCount'],
+      [Sequelize.fn('MAX', Sequelize.col('vvElectionDate')), 'mostRecentElectionDate'],
+    ],
+    include: [ { model: AgencyModel, attributes: ['name'] } ],
+    group: [ 'agencyShortName', 'name', ], 
+    raw: true,
+  })
+  
+  return results;
+}
+
+
+/**
+ * @param {string} agencyShortName - Example: "CSD"
+ */
+async function getElectionsFromDB(agencyShortName) {
+  const results = await CandidateModel.count({
+    col: ['fullOfficeName'],
+    distinct: true,
+    group: ['fullElectionTitle'],
+    where: { 'agencyShortName': agencyShortName },
+    raw: true,
+    attributes: [
+      'fullElectionTitle',
+      [Sequelize.fn('COUNT', Sequelize.col('fullName')), 'candidatesCount'],
+      [Sequelize.fn('MAX', Sequelize.col('updatedAt')), 'lastUpdated'],
+      [Sequelize.fn('MAX', Sequelize.col('vvElectionDate')), 'electionDate'],
+    ]
+  });
+
+  return results;
+}
+
+
+module.exports = {
+  doesTableExist,
+  getAgencies,
+  getElections,
+  getAgencyElections,
+  getElectionsFromDB,
+}

--- a/app/scripts/node/cli/query.js
+++ b/app/scripts/node/cli/query.js
@@ -86,6 +86,11 @@ async function getElectionsFromDB(agencyShortName) {
     ]
   });
 
+  results.forEach(result => {
+    result.officesCount = result.count;
+    delete result.count;
+  });
+
   return results;
 }
 

--- a/app/scripts/node/cli/status.js
+++ b/app/scripts/node/cli/status.js
@@ -1,0 +1,26 @@
+'use strict';
+const db = require('../../../models/index');
+const AgencyModel = db.sequelize.models.Agency;
+const query = require('./query');
+
+
+async function agenciesStatus() {
+  const tableExits = await query.doesTableExist(AgencyModel);
+  if (!tableExits) { return { count: 0, lastUpdate: 'n/a' }; }
+
+  const agenciesList =  await AgencyModel.findAll({ raw: true });
+  const agenciesLastUpdate =  await AgencyModel.max('updatedAt');
+
+  if (agenciesList < 1) { return { count: 0, lastUpdate: 'n/a' }; }
+
+  return { 
+    count: agenciesList.length,
+    lastUpdate: `${agenciesLastUpdate.toDateString()} on`
+      + ` ${agenciesLastUpdate.toLocaleTimeString()}`
+   };
+}
+
+
+module.exports = {
+  agenciesStatus,
+}

--- a/app/scripts/node/cli/update.js
+++ b/app/scripts/node/cli/update.js
@@ -1,0 +1,90 @@
+const db = require('../../../models/index');
+const AgencyModel = db.sequelize.models.Agency;
+const CandidateModel = db.sequelize.models.Candidate;
+
+const netFileAgencies = require('../netfile/netfileAgencies');
+const query = require('./query');
+
+
+/**
+ * @param {object|object[]} instances 
+ * @param {object} model 
+ */
+async function updateInstancesInModel(instances, model) {
+  instances = Array.isArray(instances) ? instances : [ instances ];
+
+  const tableExits = await query.doesTableExist(model);
+  
+  if (!tableExits) {
+    await model.sync();
+  }
+  
+  for await(instance of instances) {
+    await model.upsert(instance);
+  }
+}
+
+async function updateAgencies() {
+  const agencies = await netFileAgencies.getAgencies();
+  await updateInstancesInModel(agencies, AgencyModel);
+}
+
+
+/**
+ * @param {object|object[]} electionData 
+ * @param {string} agencyShortName - Example: "CSD"
+ */
+function transformCandidateElectionData(electionData, agencyShortName) {
+  electionData = Array.isArray(electionData) ? electionData : [ electionData ];
+
+  let candidateData = [];
+
+  electionData.forEach(election => {
+    const offices = election.electionItems.find(item => item.name === "Candidates").elements;
+    
+    offices.forEach(office => {
+      
+      if (!office.elements) { return; }
+
+      office.elements.forEach(candidate => {
+
+        candidateData.push({
+          agencyShortName: agencyShortName,
+          fullName: candidate.name,
+          fullOfficeName: office.name,
+          fullElectionTitle: election.cycle,
+        });
+
+      });
+
+    });
+
+  });
+  
+  return candidateData;
+}
+
+
+/**
+ * @param {string} electionTitle - Example: "11/03/2020 General Election"
+ * @param {string} shortName - Example: "CSD"
+ */
+async function updateElections(electionTitle, shortName){
+  const netFilePortalScraper = require('../netfile/publicPortalWebScraper');
+
+  const candidates = await netFilePortalScraper.getMultipleElectionCycleCandidates(shortName, electionTitle);
+
+  if (!candidates) { return false; }
+  
+  const transformedResults = transformCandidateElectionData(candidates, shortName);
+
+  await updateInstancesInModel(transformedResults, CandidateModel);
+
+  return true;
+}
+
+
+module.exports = {
+  updateAgencies,
+  updateElections,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,21 @@
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
+    "ansi-escapes": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+        }
+      }
+    },
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -481,6 +496,11 @@
       "integrity": "sha512-bua/2cZEfzS6qPm0vi3JEvGNbriDLcMj9lKxCQOjUcCJRcyjA7umP0zZm6bKWWlBN04vA0L99QGH/CZQawr0eg==",
       "dev": true
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -541,6 +561,19 @@
           "dev": true
         }
       }
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
     },
     "cliui": {
       "version": "5.0.0",
@@ -1007,6 +1040,16 @@
         }
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -1030,6 +1073,14 @@
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
+      }
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "filelist": {
@@ -1345,6 +1396,104 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "ioredis": {
       "version": "4.19.4",
@@ -1756,6 +1905,11 @@
         "mime-db": "1.45.0"
       }
     },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -1907,6 +2061,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
     "nanoid": {
       "version": "3.1.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
@@ -2024,6 +2183,19 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -2454,6 +2626,15 @@
         "lowercase-keys": "^1.0.0"
       }
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -2473,6 +2654,19 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+    },
+    "rxjs": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "requires": {
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -2632,8 +2826,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sinon": {
       "version": "9.2.4",
@@ -2775,6 +2968,14 @@
         "next-tick": "1"
       }
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-readable-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
@@ -2808,6 +3009,11 @@
       "requires": {
         "nopt": "~1.0.10"
       }
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "type": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "node app/server.js",
     "dev": "nodemon app/server.js",
+    "cli": "node app/scripts/node/cli/index.js",
     "test": "set NODE_ENV=test&& mocha ./app/test --exit"
   },
   "homepage": "https://github.com/opensandiego/sdvv-backend#readme",
@@ -25,6 +26,7 @@
     "csvjson": "^5.1.0",
     "ejs": "^3.1.5",
     "express": "^4.17.1",
+    "inquirer": "^7.3.3",
     "ioredis": "^4.19.4",
     "node-fetch": "^2.6.1",
     "p-retry": "^4.3.0",


### PR DESCRIPTION
Adds a command line interface to help populate the database with agency, election, and basic candidate data. This was created using the [inquirer.js](https://www.npmjs.com/package/inquirer) library.

To run the CLI:

1. Start the postgres_dev container in Docker
2. Use `npm run cli`


Screenshots of CLI

![image](https://user-images.githubusercontent.com/1051611/109613378-e8658980-7ae5-11eb-93da-c5d0b7469950.png)

![Code_2021-03-01_23-33-02](https://user-images.githubusercontent.com/1051611/109613731-6de93980-7ae6-11eb-89d7-36f4d2a64f47.png)

![Code_2021-03-01_23-32-38](https://user-images.githubusercontent.com/1051611/109613748-72aded80-7ae6-11eb-9a28-9c07b8ff1914.png)
