### PR TITLE
Fixes failing e2e test 

### DIFF
--- a/apps/sdvv-backend-nest/test/app.e2e-spec.ts
+++ b/apps/sdvv-backend-nest/test/app.e2e-spec.ts
@@ -19,6 +19,6 @@ describe('AppController (e2e)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('Hello World!');
+      .expect('Hello from the Voters Voice Dashboard!');
   });
 });

--- a/apps/sdvv-backend-nest/test/jest-e2e.json
+++ b/apps/sdvv-backend-nest/test/jest-e2e.json
@@ -5,5 +5,9 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@app/sdvv-database(|/.*)$": "<rootDir>../../../libs/sdvv-database/src/$1",
+    "^@app/efile-api-data(|/.*)$": "<rootDir>../../../libs/efile-api-data/src/$1"
   }
 }


### PR DESCRIPTION
When running the `test:e2e` script in package.json the test fails when importing a module from a library. 
The test is not able to import EfileApiDataModule since it is referenced by '@app/efile-api-data'. 

This was resolved by copying the moduleNameMapper object from the package.json into 'apps\sdvv-backend-nest\test\jest-e2e.json' and modifying the paths.

The solution was found from: https://stackoverflow.com/questions/66956387/nestjs-e2e-testing-of-an-application-within-a-monorepo-fails-to-resolve-app-imp